### PR TITLE
feat: add download button to song tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,47 @@
                 });
             });
 
+            // Download song function
+            function downloadSong(day) {
+                const downloadButton = this;
+                const originalHTML = downloadButton.innerHTML;
+                
+                // Show loading state
+                downloadButton.innerHTML = `
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="spinner">
+                        <path d="M21 12a9 9 0 11-6.219-8.56"/>
+                    </svg>
+                `;
+                downloadButton.disabled = true;
+                
+                // Create download link
+                const link = document.createElement('a');
+                const song = songs[day];
+                const filename = song ? `${song.artist} - ${song.title}.mp3` : `Day ${day}.mp3`;
+                
+                link.href = `music/${day}.mp3`;
+                link.download = filename;
+                link.style.display = 'none';
+                
+                // Add to body, click, and remove
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                
+                // Show success state
+                downloadButton.innerHTML = `
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="20 6 9 17 4 12"></polyline>
+                    </svg>
+                `;
+                
+                // Reset button after delay
+                setTimeout(() => {
+                    downloadButton.innerHTML = originalHTML;
+                    downloadButton.disabled = false;
+                }, 1500);
+            }
+
             // Create 24 day boxes
             for (let i = 1; i <= 24; i++) {
                 const dayBox = document.createElement('div');
@@ -336,6 +377,25 @@
                         </svg>
                     `;
                     dayBox.appendChild(favoriteIndicator);
+                }
+                
+                // Add download button (only for unlocked days)
+                if (!isInFuture) {
+                    const downloadButton = document.createElement('button');
+                    downloadButton.className = 'download-button';
+                    downloadButton.innerHTML = `
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                            <polyline points="7 10 12 15 17 10"></polyline>
+                            <line x1="12" y1="15" x2="12" y2="3"></line>
+                        </svg>
+                    `;
+                    downloadButton.title = `Download ${songs[i] ? songs[i].title : `Day ${i} song`}`;
+                    downloadButton.addEventListener('click', (e) => {
+                        e.stopPropagation(); // Prevent triggering day box click
+                        downloadSong.call(downloadButton, i);
+                    });
+                    dayBox.appendChild(downloadButton);
                 }
                 
                 dayBox.appendChild(img);

--- a/styles.css
+++ b/styles.css
@@ -288,6 +288,48 @@ body {
     fill: #fff;
 }
 
+.download-button {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background-color: rgba(0, 0, 0, 0.8);
+    border: none;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: white;
+    opacity: 0;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 2;
+}
+
+.day-box:hover .download-button {
+    opacity: 1;
+}
+
+.download-button:hover {
+    background-color: rgba(255, 85, 0, 0.9);
+    transform: scale(1.1);
+}
+
+.download-button svg {
+    width: 20px;
+    height: 20px;
+}
+
+.download-button .spinner {
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 .lyrics-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
- Add download button that appears on hover for each unlocked song tile
- Button positioned in top-left corner with download icon
- Implements click-to-download functionality with visual feedback
- Shows loading spinner during download and checkmark on completion
- Downloads MP3 files with proper naming format: "Artist - Title.mp3"
- Includes hover effects and smooth transitions

🤖 Generated with [Claude Code](https://claude.ai/code)